### PR TITLE
Direct Port Manipulation

### DIFF
--- a/arduinix-chess-clock.ino
+++ b/arduinix-chess-clock.ino
@@ -21,8 +21,9 @@ const int STATUS_UPDATE_MAX_CHARS = 30;
 
 // TODO - test for ideal values on ИH-2 and ИH-12A tubes
 //      - calculate corresponding Hz
-const int MULTIPLEX_SINGLE_TUBE_LIT_DURATION_US = 800;
-const int MULTIPLEX_SINGLE_TUBE_OFF_DURATION_US = 300;
+const int MULTIPLEX_SINGLE_TUBE_LIT_DURATION_US = 1100;
+const int MULTIPLEX_SINGLE_TUBE_OFF_DURATION_US = 200;
+const int MULTIPLEX_HV_STABILIZATION_DELAY_US = 5;
 
 /*
  * ===============================
@@ -196,6 +197,7 @@ inline void displayOnTubeExclusive(byte tubeIndex, byte displayVal) {
   // LOW mask PORTB first to power OFF Anodes FIRST
   PORTB &= ~portBLowBitmask;
   PORTD &= ~portDLowBitmask;
+  delayMicroseconds(MULTIPLEX_HV_STABILIZATION_DELAY_US);
 
   // HIGH mask PORTD first to power ON Anodes LAST
   PORTD |= portDHighBitmask;

--- a/arduinix-chess-clock.ino
+++ b/arduinix-chess-clock.ino
@@ -10,21 +10,22 @@
  */
 const long SERIAL_SPEED_BAUD = 115200L;
 const int JACKPOT_STEP_DURATION_MS = 50;
-const int JACKPOT_DURATION_MS = JACKPOT_STEP_DURATION_MS * DIGITS_PER_TUBE * 5;
+const int JACKPOT_FULL_ROUNDS = 5;
+const int JACKPOT_DURATION_MS = JACKPOT_STEP_DURATION_MS * DIGITS_PER_TUBE * JACKPOT_FULL_ROUNDS;
 const unsigned long JACKPOT_MIN_ELAPSED_MS = 1000UL;
 const unsigned long JACKPOT_MIN_REMAINING_MS = 61000UL;
+const unsigned long MAX_DISPLAY_ELAPSED_MS = 359999900UL; // 99:59:59:900
 const int TIMEOUT_BLINK_DURATION_MS = 500;
 const int MENU_BLINK_DURATION_MS = 300;
 const int BUTTON_DEBOUNCE_DELAY_MS = 20;
 const int STATUS_UPDATE_INTERVAL_MS = 1000;
 const int STATUS_UPDATE_MAX_CHARS = 30;
-const unsigned long MAX_DISPLAY_ELAPSED_MS = 359999900UL; // 99:59:59:900
-
-// TODO - test for ideal values on ИH-2 and ИH-12A tubes
-//      - calculate corresponding Hz
-const int MULTIPLEX_SINGLE_TUBE_LIT_DURATION_US = 1100;
-const int MULTIPLEX_SINGLE_TUBE_OFF_DURATION_US = 200;
 const int MULTIPLEX_HV_STABILIZATION_DELAY_US = 5;
+
+// ~120Hz / tube - tested on ИH-2 and ИH-12A tubes
+// using a 1.4ms (1400µs) per-tube cycle: 1000ms / (1.4ms/tube * 6tubes)
+const int MULTIPLEX_SINGLE_TUBE_LIT_DURATION_US = 1200; // ~86% lit
+const int MULTIPLEX_SINGLE_TUBE_OFF_DURATION_US = 200;  // ~14% off
 
 /*
  * ===============================
@@ -58,7 +59,6 @@ unsigned long turnStartTimestampMS = 0UL;
 bool leftPlayersTurn = false;
 bool blinkOn = false;
 bool jackpotOn = false;
-bool jackpotDirectionFTB = true;
 byte jackpotDigitOrderIndexValues[TUBE_COUNT] = {0, 0, 0, 0, 0, 0};
 char statusUpdate[STATUS_UPDATE_MAX_CHARS] = "";
 byte currentTurnTimerOption = 2;

--- a/arduinix-chess-clock.ino
+++ b/arduinix-chess-clock.ino
@@ -3,10 +3,6 @@
 #include "clock-hardware.h"
 #include "clock-data-types.h"
 
-const int LOOP_TIME_SAMPLE_COUNT = 100;
-int LOOP_TIME_SAMPLE_IDX = 0;
-int LOOP_TIME_SAMPLES_US[LOOP_TIME_SAMPLE_COUNT];
-
 /*
  * ===============================
  *  Behavior Constants
@@ -21,12 +17,12 @@ const int TIMEOUT_BLINK_DURATION_MS = 500;
 const int MENU_BLINK_DURATION_MS = 300;
 const int BUTTON_DEBOUNCE_DELAY_MS = 20;
 const int STATUS_UPDATE_INTERVAL_MS = 1000;
-const int STATUS_UPDATE_MAX_CHARS = 40;
+const int STATUS_UPDATE_MAX_CHARS = 30;
 
-// 300µs - 500µs is recommended. Assuming TUBE_COUNT == 6 this is equivalent to
-// a per-tube refresh rate of 92.5Hz - 55.5Hz. Tested on ИH-2 and ИH-12A tubes.
-const int MULTIPLEX_SINGLE_TUBE_LIT_DURATION_US = 500;
-const int MULTIPLEX_SINGLE_TUBE_OFF_DURATION_US = 100;
+// TODO - test for ideal values on ИH-2 and ИH-12A tubes
+//      - calculate corresponding Hz
+const int MULTIPLEX_SINGLE_TUBE_LIT_DURATION_US = 800;
+const int MULTIPLEX_SINGLE_TUBE_OFF_DURATION_US = 300;
 
 /*
  * ===============================
@@ -76,24 +72,16 @@ void setup()
   pinMode(PIN_ANODE_2, OUTPUT);
   pinMode(PIN_ANODE_3, OUTPUT);
   pinMode(PIN_ANODE_4, OUTPUT);
-  
   pinMode(PIN_CATHODE_0_A, OUTPUT);
   pinMode(PIN_CATHODE_0_B, OUTPUT);
   pinMode(PIN_CATHODE_0_C, OUTPUT);
   pinMode(PIN_CATHODE_0_D, OUTPUT);
-  
   pinMode(PIN_CATHODE_1_A, OUTPUT);
   pinMode(PIN_CATHODE_1_B, OUTPUT);
   pinMode(PIN_CATHODE_1_C, OUTPUT);
   pinMode(PIN_CATHODE_1_D, OUTPUT);
   
-  digitalWrite(PIN_ANODE_1, LOW);
-  digitalWrite(PIN_ANODE_2, LOW);
-  digitalWrite(PIN_ANODE_3, LOW);
-  digitalWrite(PIN_ANODE_4, LOW);
-  
-  setCathode(true, BLANK);
-  setCathode(false, BLANK);
+  displayOnTubeExclusive(0, BLANK);
 
   // use analog inputs as digital inputs for buttons
   pinMode(PIN_BUTTON_RIGHT, INPUT_PULLUP);
@@ -103,18 +91,14 @@ void setup()
   // use analog inputs as digital outputs for button LEDs
   pinMode(PIN_BUTTON_RIGHT_LED, OUTPUT);
   pinMode(PIN_BUTTON_LEFT_LED, OUTPUT);
-  digitalWrite(PIN_BUTTON_RIGHT_LED, LOW);
-  digitalWrite(PIN_BUTTON_LEFT_LED, LOW);
 
   // ground for button assembly
   pinMode(PIN_BUTTON_GROUND, OUTPUT);
   digitalWrite(PIN_BUTTON_GROUND, LOW);
 
-  Serial.begin(SERIAL_SPEED_BAUD);
+  setButtonLEDs(false, false);
 
-  for (int i=0; i < LOOP_TIME_SAMPLE_COUNT; i++) {
-    LOOP_TIME_SAMPLES_US[i] = 0;
-  }
+  Serial.begin(SERIAL_SPEED_BAUD);
 }
 
 /*
@@ -123,67 +107,14 @@ void setup()
  * ===============================
  */
 
-void setCathode(boolean ctrl0, byte displayNumber) {
-  byte a, b, c, d;
-  d = c = b = a = 1;
-  
-  // given a decimal display number, set the matching binary representation
-  // as input to the specified cathode controller
-  switch(displayNumber) {
-    case 0: d=0; c=0; b=0; a=0; break;
-    case 1: d=0; c=0; b=0; a=1; break;
-    case 2: d=0; c=0; b=1; a=0; break;
-    case 3: d=0; c=0; b=1; a=1; break;
-    case 4: d=0; c=1; b=0; a=0; break;
-    case 5: d=0; c=1; b=0; a=1; break;
-    case 6: d=0; c=1; b=1; a=0; break;
-    case 7: d=0; c=1; b=1; a=1; break;
-    case 8: d=1; c=0; b=0; a=0; break;
-    case 9: d=1; c=0; b=0; a=1; break;
-    default: d=1; c=1; b=1; a=1;
-  }  
-  
-  if (ctrl0) {
-    digitalWrite(PIN_CATHODE_0_D, d);
-    digitalWrite(PIN_CATHODE_0_C, c);
-    digitalWrite(PIN_CATHODE_0_B, b);
-    digitalWrite(PIN_CATHODE_0_A, a);
-  } else {
-    digitalWrite(PIN_CATHODE_1_D, d);
-    digitalWrite(PIN_CATHODE_1_C, c);
-    digitalWrite(PIN_CATHODE_1_B, b);
-    digitalWrite(PIN_CATHODE_1_A, a);
-  }
-}
-
-void setAnode(byte anode, byte displayVal) {
-  switch(anode) {
-    case 1:
-      digitalWrite(PIN_ANODE_2, LOW);
-      digitalWrite(PIN_ANODE_3, LOW);
-      digitalWrite(PIN_ANODE_1, displayVal == BLANK ? LOW : HIGH);
-      break;
-    case 2:
-      digitalWrite(PIN_ANODE_1, LOW);
-      digitalWrite(PIN_ANODE_3, LOW);
-      digitalWrite(PIN_ANODE_2, displayVal == BLANK ? LOW : HIGH);
-      break;
-    case 3:
-      digitalWrite(PIN_ANODE_1, LOW);
-      digitalWrite(PIN_ANODE_2, LOW);
-      digitalWrite(PIN_ANODE_3, displayVal == BLANK ? LOW : HIGH);
-      break;
-  }
-}
-
-void displayOnTubeExclusiveDPM(byte tubeIndex, byte displayVal) {
+inline void displayOnTubeExclusive(byte tubeIndex, byte displayVal) {
   byte anode = TUBE_ANODES[tubeIndex];
   bool cathodeCtrl0 = TUBE_CATHODE_CTRL_0[tubeIndex];
   
   byte c0Val, c1Val;
 
-  // blank the other cathode so that the anode for the specified tube won't
-  // light both of the tubes that it's connected to when activated
+  // blank the non-active cathode so that the anode for the specified tube
+  // won't light both of the tubes that it's connected to when activated
   if (cathodeCtrl0) {
     c0Val = displayVal;
     c1Val = BLANK;
@@ -192,7 +123,7 @@ void displayOnTubeExclusiveDPM(byte tubeIndex, byte displayVal) {
     c1Val = displayVal;
   }
 
-  // 4 bitmasks to be used when setting PORTB and PORTD hardware registers,
+  // bitmasks to be used when setting PORTB and PORTD hardware registers,
   // aka Direct Port Manipulation
   byte portBHighBitmask, portBLowBitmask, portDHighBitmask, portDLowBitmask;
   portBHighBitmask = portBLowBitmask = portDHighBitmask = portDLowBitmask = 0;
@@ -271,18 +202,18 @@ void displayOnTubeExclusiveDPM(byte tubeIndex, byte displayVal) {
   PORTB |= portBHighBitmask;
 }
 
-void displayOnTubeExclusive(byte tubeIndex, byte displayVal) {
-  byte anode = TUBE_ANODES[tubeIndex];
-  bool cathodeCtrl0 = TUBE_CATHODE_CTRL_0[tubeIndex];
-  
-  setAnode(anode, displayVal);
-  setCathode(!cathodeCtrl0, BLANK);
-  setCathode(cathodeCtrl0, displayVal);
-}
+inline void setButtonLEDs(bool leftOn, bool rightOn) {
+  if (leftOn) {
+    PORTC |= PIN_BUTTON_LEFT_LED_DPM_BIT;
+  } else {
+    PORTC &= ~PIN_BUTTON_LEFT_LED_DPM_BIT;
+  }
 
-void setButtonLEDs(bool leftOn, bool rightOn) {
-  digitalWrite(PIN_BUTTON_LEFT_LED, leftOn ? HIGH : LOW);
-  digitalWrite(PIN_BUTTON_RIGHT_LED, rightOn ? HIGH : LOW);
+  if (rightOn) {
+    PORTC |= PIN_BUTTON_RIGHT_LED_DPM_BIT;
+  } else {
+    PORTC &= ~PIN_BUTTON_RIGHT_LED_DPM_BIT;
+  }
 }
 
 /*
@@ -291,7 +222,7 @@ void setButtonLEDs(bool leftOn, bool rightOn) {
  * ===============================
  */
 
-void setMultiplexDisplay(byte t0, byte t1, byte t2, byte t3, byte t4, byte t5) {
+inline void setMultiplexDisplay(byte t0, byte t1, byte t2, byte t3, byte t4, byte t5) {
   multiplexDisplayValues[0] = t0;
   multiplexDisplayValues[1] = t1;
   multiplexDisplayValues[2] = t2;
@@ -300,10 +231,9 @@ void setMultiplexDisplay(byte t0, byte t1, byte t2, byte t3, byte t4, byte t5) {
   multiplexDisplayValues[5] = t5;
 }
 
-void loopMultiplex() {
+inline void loopMultiplex() {
   if (multiplexIsLit && micros() - lastDisplayRefreshTimestampUS >= MULTIPLEX_SINGLE_TUBE_LIT_DURATION_US) {
-    displayOnTubeExclusiveDPM(lastDisplayRefreshTubeIndex, BLANK);
-    // displayOnTubeExclusive(lastDisplayRefreshTubeIndex, BLANK);
+    displayOnTubeExclusive(lastDisplayRefreshTubeIndex, BLANK);
     multiplexIsLit = false;
     lastDisplayRefreshTimestampUS = micros();
   } else if (!multiplexIsLit && micros() - lastDisplayRefreshTimestampUS >= MULTIPLEX_SINGLE_TUBE_OFF_DURATION_US) {
@@ -313,14 +243,13 @@ void loopMultiplex() {
       lastDisplayRefreshTubeIndex--;
     }
 
-    displayOnTubeExclusiveDPM(lastDisplayRefreshTubeIndex, multiplexDisplayValues[lastDisplayRefreshTubeIndex]);
-    // displayOnTubeExclusive(lastDisplayRefreshTubeIndex, multiplexDisplayValues[lastDisplayRefreshTubeIndex]);
+    displayOnTubeExclusive(lastDisplayRefreshTubeIndex, multiplexDisplayValues[lastDisplayRefreshTubeIndex]);
     multiplexIsLit = true;
     lastDisplayRefreshTimestampUS = micros();
   }
 }
 
-void handleJackpot(unsigned long loopNow) {
+inline void handleJackpot(unsigned long loopNow) {
   setMultiplexDisplay(
     TUBE_DIGIT_ORDER[jackpotDigitOrderIndexValues[0]],
     TUBE_DIGIT_ORDER[jackpotDigitOrderIndexValues[1]],
@@ -347,7 +276,7 @@ void handleJackpot(unsigned long loopNow) {
   }
 }
 
-void setMultiplexClockTime(unsigned long elapsedMS, unsigned long remainingMS, unsigned long loopNow, bool displayElapsed) {
+inline void setMultiplexClockTime(unsigned long elapsedMS, unsigned long remainingMS, unsigned long loopNow, bool displayElapsed) {
   unsigned long totalMS = displayElapsed ? elapsedMS : remainingMS;
   unsigned long totalSec = totalMS / 1000;
   int hours = totalSec / 3600;
@@ -388,7 +317,7 @@ void setMultiplexClockTime(unsigned long elapsedMS, unsigned long remainingMS, u
   }
 }
 
-CountdownValues loopCountdown(unsigned long loopNow) {
+inline CountdownValues loopCountdown(unsigned long loopNow) {
   unsigned long timeoutLimit = TURN_TIMER_OPTIONS[currentTurnTimerOption].turnLimitMS;
   unsigned long elapsedMS = loopNow - turnStartTimestampMS;
   unsigned long remainingMS = timeoutLimit - elapsedMS;
@@ -410,7 +339,7 @@ CountdownValues loopCountdown(unsigned long loopNow) {
   return { elapsedMS, remainingMS };
 }
 
-void loopTimeout(unsigned long loopNow) {
+inline void loopTimeout(unsigned long loopNow) {
   if (loopNow - lastEventStepTimestampMS > TIMEOUT_BLINK_DURATION_MS) {
     lastEventStepTimestampMS = loopNow;
     blinkOn = !blinkOn;
@@ -430,7 +359,7 @@ void loopTimeout(unsigned long loopNow) {
   }
 }
 
-void loopMenu(unsigned long loopNow) {
+inline void loopMenu(unsigned long loopNow) {
   if (loopNow - lastEventStepTimestampMS > MENU_BLINK_DURATION_MS) {
     lastEventStepTimestampMS = loopNow;
     blinkOn = !blinkOn;
@@ -452,33 +381,26 @@ void loopMenu(unsigned long loopNow) {
   }
 }
 
-void loopIdle() {
+inline void loopIdle() {
   setButtonLEDs(false, false);
   setMultiplexDisplay(BLANK, BLANK, BLANK, BLANK, BLANK, BLANK);
 }
 
-void loopSendStatusUpdate(unsigned long loopNow, unsigned long elapsedMs, unsigned long remainingMs) {
+inline void loopSendStatusUpdate(unsigned long loopNow, unsigned long elapsedMs, unsigned long remainingMs) {
   if (loopNow - lastStatusUpdateTimestampMS > STATUS_UPDATE_INTERVAL_MS) {
-    // unsigned long allSamplesUS = 0;
-    // for (int i=0; i < LOOP_TIME_SAMPLE_COUNT; i++) {
-    //   allSamplesUS += LOOP_TIME_SAMPLES_US[i];
-    // }
-
-    snprintf(statusUpdate, STATUS_UPDATE_MAX_CHARS, "%d,%s,%d,%lu,%lu,%lu",
+    snprintf(statusUpdate, STATUS_UPDATE_MAX_CHARS, "%d,%s,%d,%lu,%lu",
       currentClockState,
       TURN_TIMER_OPTIONS[currentTurnTimerOption].label,
       leftPlayersTurn,
       elapsedMs,
-      remainingMs,
-      // allSamplesUS / LOOP_TIME_SAMPLE_COUNT
-      0UL
+      remainingMs
     );
     Serial.println(statusUpdate);
     lastStatusUpdateTimestampMS = millis();
   }
 }
 
-void handleRightButtonPress(unsigned long loopNow) {
+inline void handleRightButtonPress(unsigned long loopNow) {
   if (currentClockState == RUNNING && !leftPlayersTurn) {
     leftPlayersTurn = !leftPlayersTurn;
     turnStartTimestampMS = loopNow;
@@ -497,7 +419,7 @@ void handleRightButtonPress(unsigned long loopNow) {
   }
 }
 
-void handleLeftButtonPress(unsigned long loopNow) {
+inline void handleLeftButtonPress(unsigned long loopNow) {
   if (currentClockState == RUNNING && leftPlayersTurn) {
     leftPlayersTurn = !leftPlayersTurn;
     turnStartTimestampMS = loopNow;
@@ -516,7 +438,7 @@ void handleLeftButtonPress(unsigned long loopNow) {
   }
 }
 
-void handleUtilityButtonPress(unsigned long loopNow) {
+inline void handleUtilityButtonPress(unsigned long loopNow) {
   if (currentClockState == IDLE) {
     currentClockState = MENU;
   } else if (currentClockState == DEMO || currentClockState == MENU || currentClockState == TIMEOUT || currentClockState == RUNNING) {
@@ -525,10 +447,10 @@ void handleUtilityButtonPress(unsigned long loopNow) {
   }
 }
 
-void loopCheckButtons(unsigned long loopNow) {
-  byte rightButtonReading = digitalRead(PIN_BUTTON_RIGHT);
-  byte leftButtonReading = digitalRead(PIN_BUTTON_LEFT);
-  byte utilityButtonReading = digitalRead(PIN_BUTTON_UTILITY);
+inline void loopCheckButtons(unsigned long loopNow) {
+  byte rightButtonReading = PINC & PIN_BUTTON_RIGHT_DPM_BIT;
+  byte leftButtonReading = PINC & PIN_BUTTON_LEFT_DPM_BIT;
+  byte utilityButtonReading = PINC & PIN_BUTTON_UTILITY_DPM_BIT;
 
   // handle press state change (set debounce timer)
   if (rightButtonReading != rightButtonLastVal) {
@@ -586,8 +508,6 @@ void loopCheckButtons(unsigned long loopNow) {
  * ============================
  */
 void loop() {
-  unsigned long loopStartUS = micros();
-
   unsigned long now = millis();
 
   // check for button presses and change state if needed
@@ -613,9 +533,4 @@ void loop() {
   loopMultiplex();
 
   loopSendStatusUpdate(now, cv.elapsedMS, cv.remainingMS);
-
-  LOOP_TIME_SAMPLES_US[LOOP_TIME_SAMPLE_IDX] = micros() - loopStartUS;
-  if (LOOP_TIME_SAMPLE_IDX < LOOP_TIME_SAMPLE_COUNT - 1) {
-    LOOP_TIME_SAMPLE_IDX++;
-  }
 }

--- a/arduinix-chess-clock.ino
+++ b/arduinix-chess-clock.ino
@@ -25,7 +25,7 @@ const int STATUS_UPDATE_MAX_CHARS = 40;
 
 // 300µs - 500µs is recommended. Assuming TUBE_COUNT == 6 this is equivalent to
 // a per-tube refresh rate of 92.5Hz - 55.5Hz. Tested on ИH-2 and ИH-12A tubes.
-const int MULTIPLEX_SINGLE_TUBE_LIT_DURATION_US = 300;
+const int MULTIPLEX_SINGLE_TUBE_LIT_DURATION_US = 500;
 const int MULTIPLEX_SINGLE_TUBE_OFF_DURATION_US = 100;
 
 /*
@@ -35,19 +35,19 @@ const int MULTIPLEX_SINGLE_TUBE_OFF_DURATION_US = 100;
  */
 
 // button state 🔘🔘
-int rightButtonLastVal = HIGH;
-int leftButtonLastVal = HIGH;
-int utilityButtonLastVal = HIGH;
-int rightButtonVal = HIGH;
-int leftButtonVal = HIGH;
-int utilityButtonVal = HIGH;
+byte rightButtonLastVal = HIGH;
+byte leftButtonLastVal = HIGH;
+byte utilityButtonLastVal = HIGH;
+byte rightButtonVal = HIGH;
+byte leftButtonVal = HIGH;
+byte utilityButtonVal = HIGH;
 unsigned long rightButtonLastDebounceMS = 0UL;
 unsigned long leftButtonLastDebounceMS = 0UL;
 unsigned long utilityButtonLastDebounceMS = 0UL;
 
 // nixie tube state 🚥🚥
-int multiplexDisplayValues[TUBE_COUNT] = {BLANK, BLANK, BLANK, BLANK, BLANK, BLANK};
-int lastDisplayRefreshTubeIndex = TUBE_COUNT;
+byte multiplexDisplayValues[TUBE_COUNT] = {BLANK, BLANK, BLANK, BLANK, BLANK, BLANK};
+byte lastDisplayRefreshTubeIndex = TUBE_COUNT;
 unsigned long lastDisplayRefreshTimestampUS = 0UL;
 bool multiplexIsLit = false;
 
@@ -61,9 +61,9 @@ bool leftPlayersTurn = false;
 bool blinkOn = false;
 bool jackpotOn = false;
 bool jackpotDirectionFTB = true;
-int jackpotDigitOrderIndexValues[TUBE_COUNT] = {0, 0, 0, 0, 0, 0};
+byte jackpotDigitOrderIndexValues[TUBE_COUNT] = {0, 0, 0, 0, 0, 0};
 char statusUpdate[STATUS_UPDATE_MAX_CHARS] = "";
-int currentTurnTimerOption = 2;
+byte currentTurnTimerOption = 2;
 
 /*
  * ===============================
@@ -123,7 +123,7 @@ void setup()
  * ===============================
  */
 
-void setCathode(boolean ctrl0, int displayNumber) {
+void setCathode(boolean ctrl0, byte displayNumber) {
   byte a, b, c, d;
   d = c = b = a = 1;
   
@@ -156,7 +156,7 @@ void setCathode(boolean ctrl0, int displayNumber) {
   }
 }
 
-void setAnode(int anode, int displayVal) {
+void setAnode(byte anode, byte displayVal) {
   switch(anode) {
     case 1:
       digitalWrite(PIN_ANODE_2, LOW);
@@ -176,8 +176,8 @@ void setAnode(int anode, int displayVal) {
   }
 }
 
-void displayOnTubeExclusiveDPM(int tubeIndex, int displayVal) {
-  int anode = TUBE_ANODES[tubeIndex];
+void displayOnTubeExclusiveDPM(byte tubeIndex, byte displayVal) {
+  byte anode = TUBE_ANODES[tubeIndex];
   bool cathodeCtrl0 = TUBE_CATHODE_CTRL_0[tubeIndex];
   
   byte c0Val, c1Val;
@@ -271,8 +271,8 @@ void displayOnTubeExclusiveDPM(int tubeIndex, int displayVal) {
   PORTB |= portBHighBitmask;
 }
 
-void displayOnTubeExclusive(int tubeIndex, int displayVal) {
-  int anode = TUBE_ANODES[tubeIndex];
+void displayOnTubeExclusive(byte tubeIndex, byte displayVal) {
+  byte anode = TUBE_ANODES[tubeIndex];
   bool cathodeCtrl0 = TUBE_CATHODE_CTRL_0[tubeIndex];
   
   setAnode(anode, displayVal);
@@ -291,7 +291,7 @@ void setButtonLEDs(bool leftOn, bool rightOn) {
  * ===============================
  */
 
-void setMultiplexDisplay(int t0, int t1, int t2, int t3, int t4, int t5) {
+void setMultiplexDisplay(byte t0, byte t1, byte t2, byte t3, byte t4, byte t5) {
   multiplexDisplayValues[0] = t0;
   multiplexDisplayValues[1] = t1;
   multiplexDisplayValues[2] = t2;
@@ -335,7 +335,7 @@ void handleJackpot(unsigned long loopNow) {
     jackpotOn = false;
   } else if (loopNow - lastEventStepTimestampMS > JACKPOT_STEP_DURATION_MS) {
     // advance to next jackpot step
-    for (int i = 0; i < TUBE_COUNT; i++) {
+    for (byte i = 0; i < TUBE_COUNT; i++) {
       if (jackpotDigitOrderIndexValues[i] == 9) {
         jackpotDigitOrderIndexValues[i] = 0;
       } else {
@@ -362,7 +362,7 @@ void setMultiplexClockTime(unsigned long elapsedMS, unsigned long remainingMS, u
     jackpotOn = true;
     lastJackpotTimestampMS = loopNow;
     
-    for (int i = 0; i < TUBE_COUNT; i++) {
+    for (byte i = 0; i < TUBE_COUNT; i++) {
       jackpotDigitOrderIndexValues[i] = 9;
     }
   }
@@ -526,9 +526,9 @@ void handleUtilityButtonPress(unsigned long loopNow) {
 }
 
 void loopCheckButtons(unsigned long loopNow) {
-  int rightButtonReading = digitalRead(PIN_BUTTON_RIGHT);
-  int leftButtonReading = digitalRead(PIN_BUTTON_LEFT);
-  int utilityButtonReading = digitalRead(PIN_BUTTON_UTILITY);
+  byte rightButtonReading = digitalRead(PIN_BUTTON_RIGHT);
+  byte leftButtonReading = digitalRead(PIN_BUTTON_LEFT);
+  byte utilityButtonReading = digitalRead(PIN_BUTTON_UTILITY);
 
   // handle press state change (set debounce timer)
   if (rightButtonReading != rightButtonLastVal) {

--- a/clock-data-types.h
+++ b/clock-data-types.h
@@ -35,8 +35,13 @@ const TurnTimerOption TURN_TIMER_OPTIONS[TURN_TIMER_OPTIONS_COUNT] = {
   { { BLANK, BLANK, 0, 5, BLANK, BLANK }, 300000UL, "5m" },
   { { BLANK, BLANK, 0, 3, BLANK, BLANK }, 180000UL, "3m" },
   { { BLANK, BLANK, 0, 1, BLANK, BLANK }, 60000UL, "1m" },
-  { { BLANK, BLANK, BLANK, BLANK, 1, 0 }, 10000UL, "10s" },     // for testing
+  { { BLANK, BLANK, BLANK, BLANK, 1, 0 }, 10000UL, "10s" },
   { { BLANK, BLANK, BLANK, BLANK, BLANK, 0 }, 0UL, "n0L" }
 };
+
+const byte BIT_0 = 1 << 0;
+const byte BIT_1 = 1 << 1;
+const byte BIT_2 = 1 << 2;
+const byte BIT_3 = 1 << 3;
 
 #endif _CLOCK_DATA_TYPES_H

--- a/clock-data-types.h
+++ b/clock-data-types.h
@@ -39,9 +39,4 @@ const TurnTimerOption TURN_TIMER_OPTIONS[TURN_TIMER_OPTIONS_COUNT] = {
   { { BLANK, BLANK, BLANK, BLANK, BLANK, 0 }, 0UL, "n0L" }
 };
 
-const byte BIT_0 = 1 << 0;
-const byte BIT_1 = 1 << 1;
-const byte BIT_2 = 1 << 2;
-const byte BIT_3 = 1 << 3;
-
 #endif _CLOCK_DATA_TYPES_H

--- a/clock-data-types.h
+++ b/clock-data-types.h
@@ -12,7 +12,7 @@
 enum ClockState { IDLE, RUNNING, TIMEOUT, MENU, DEMO };
 
 typedef struct {
-  int displayValues[TUBE_COUNT];
+  byte displayValues[TUBE_COUNT];
   unsigned long turnLimitMS;
   char label[4];
 } TurnTimerOption;
@@ -22,7 +22,7 @@ typedef struct {
   unsigned long remainingMS;
 } CountdownValues;
 
-const int TURN_TIMER_OPTIONS_COUNT = 13;
+const byte TURN_TIMER_OPTIONS_COUNT = 13;
 const TurnTimerOption TURN_TIMER_OPTIONS[TURN_TIMER_OPTIONS_COUNT] = {
   { { 7, 2, BLANK, BLANK, BLANK, BLANK }, 259201000UL, "72h" },
   { { 4, 8, BLANK, BLANK, BLANK, BLANK }, 172801000UL, "48h" },

--- a/clock-hardware.h
+++ b/clock-hardware.h
@@ -8,22 +8,22 @@
 #define _CLOCK_HARDWARE_H
 
 // ArduiNIX controller 0 К155ИД1 (or SN74141)
-const int PIN_CATHODE_0_A = 2;
-const int PIN_CATHODE_0_B = 3;
-const int PIN_CATHODE_0_C = 4;
-const int PIN_CATHODE_0_D = 5;
+const byte PIN_CATHODE_0_A = 2;
+const byte PIN_CATHODE_0_B = 3;
+const byte PIN_CATHODE_0_C = 4;
+const byte PIN_CATHODE_0_D = 5;
 
 // ArduiNIX controller 1 К155ИД1 (or SN74141)
-const int PIN_CATHODE_1_A = 6;
-const int PIN_CATHODE_1_B = 7;
-const int PIN_CATHODE_1_C = 8;
-const int PIN_CATHODE_1_D = 9;
+const byte PIN_CATHODE_1_A = 6;
+const byte PIN_CATHODE_1_B = 7;
+const byte PIN_CATHODE_1_C = 8;
+const byte PIN_CATHODE_1_D = 9;
 
 // ArduiNIX anode pins
-const int PIN_ANODE_1 = 10;
-const int PIN_ANODE_2 = 11;
-const int PIN_ANODE_3 = 12;
-const int PIN_ANODE_4 = 13;
+const byte PIN_ANODE_1 = 10;
+const byte PIN_ANODE_2 = 11;
+const byte PIN_ANODE_3 = 12;
+const byte PIN_ANODE_4 = 13;
 
 // Arduino Uno R1-R3 Direct Port Manipulation
 const byte PIN_CATHODE_0_A_DPM_BIT = 1 << 2;  // pin 2: PORTD bit 2
@@ -40,12 +40,12 @@ const byte PIN_ANODE_3_DPM_BIT = 1 << 4;  // pin 12: PORTB bit 4
 const byte PIN_ANODE_4_DPM_BIT = 1 << 5;  // pin 13: PORTB bit 5
 
 // button pins
-const int PIN_BUTTON_RIGHT = A0;
-const int PIN_BUTTON_LEFT = A1;
-const int PIN_BUTTON_RIGHT_LED = A2;
-const int PIN_BUTTON_LEFT_LED = A3;
-const int PIN_BUTTON_UTILITY = A4;
-const int PIN_BUTTON_GROUND = A5;
+const byte PIN_BUTTON_RIGHT = A0;
+const byte PIN_BUTTON_LEFT = A1;
+const byte PIN_BUTTON_RIGHT_LED = A2;
+const byte PIN_BUTTON_LEFT_LED = A3;
+const byte PIN_BUTTON_UTILITY = A4;
+const byte PIN_BUTTON_GROUND = A5;
 
 // The clock is designed to use 6 tubes, each one wired to a unique combination
 // of an anode pin (live power) and a cathode controller chip К155ИД1 (ground).
@@ -53,18 +53,18 @@ const int PIN_BUTTON_GROUND = A5;
 // К155ИД1/SN74141 controllers are BCD-to-decimal, and are wired such that
 // inputting 0-9 in binary will ground the associated Nixie tube cathode (and
 // light the decimal, if the anode is also active).
-const int TUBE_COUNT = 6;
-const int DIGITS_PER_TUBE = 10;
-const int TUBE_ANODES[TUBE_COUNT] = {1, 1, 2, 2, 3, 3};
+const byte TUBE_COUNT = 6;
+const byte DIGITS_PER_TUBE = 10;
+const byte TUBE_ANODES[TUBE_COUNT] = {1, 1, 2, 2, 3, 3};
 const bool TUBE_CATHODE_CTRL_0[TUBE_COUNT] = {false, true, false, true, false, true};
 
 // controller values > 9 are unwired, and result in blank display
-const int BLANK = 15;
+const byte BLANK = 15;
 
 // ИH-12A tubes
-const int TUBE_DIGIT_ORDER[] = {3, 8, 9, 4, 0, 5, 7, 2, 6, 1};
+const byte TUBE_DIGIT_ORDER[] = {3, 8, 9, 4, 0, 5, 7, 2, 6, 1};
 
 // most other tubes
-// const int TUBE_DIGIT_ORDER[] = {6, 7, 5, 8, 4, 3, 9, 2, 0, 1};
+// const byte TUBE_DIGIT_ORDER[] = {6, 7, 5, 8, 4, 3, 9, 2, 0, 1};
 
 #endif _CLOCK_HARDWARE_H

--- a/clock-hardware.h
+++ b/clock-hardware.h
@@ -25,20 +25,6 @@ const byte PIN_ANODE_2 = 11;
 const byte PIN_ANODE_3 = 12;
 const byte PIN_ANODE_4 = 13;
 
-// Arduino Uno R1-R3 Direct Port Manipulation
-const byte PIN_CATHODE_0_A_DPM_BIT = 1 << 2;  // pin 2: PORTD bit 2
-const byte PIN_CATHODE_0_B_DPM_BIT = 1 << 3;  // pin 3: PORTD bit 3
-const byte PIN_CATHODE_0_C_DPM_BIT = 1 << 4;  // pin 4: PORTD bit 4
-const byte PIN_CATHODE_0_D_DPM_BIT = 1 << 5;  // pin 5: PORTD bit 5
-const byte PIN_CATHODE_1_A_DPM_BIT = 1 << 6;  // pin 6: PORTD bit 6
-const byte PIN_CATHODE_1_B_DPM_BIT = 1 << 7;  // pin 7: PORTD bit 7
-const byte PIN_CATHODE_1_C_DPM_BIT = 1 << 0;  // pin 8: PORTB bit 0
-const byte PIN_CATHODE_1_D_DPM_BIT = 1 << 1;  // pin 9: PORTB bit 1
-const byte PIN_ANODE_1_DPM_BIT = 1 << 2;  // pin 10: PORTB bit 2
-const byte PIN_ANODE_2_DPM_BIT = 1 << 3;  // pin 11: PORTB bit 3
-const byte PIN_ANODE_3_DPM_BIT = 1 << 4;  // pin 12: PORTB bit 4
-const byte PIN_ANODE_4_DPM_BIT = 1 << 5;  // pin 13: PORTB bit 5
-
 // button pins
 const byte PIN_BUTTON_RIGHT = A0;
 const byte PIN_BUTTON_LEFT = A1;
@@ -46,6 +32,26 @@ const byte PIN_BUTTON_RIGHT_LED = A2;
 const byte PIN_BUTTON_LEFT_LED = A3;
 const byte PIN_BUTTON_UTILITY = A4;
 const byte PIN_BUTTON_GROUND = A5;
+
+// Arduino Uno R1-R3 Direct Port Manipulation
+const byte PIN_CATHODE_0_A_DPM_BIT = 1 << 2;        // pin 2: PORTD bit 2
+const byte PIN_CATHODE_0_B_DPM_BIT = 1 << 3;        // pin 3: PORTD bit 3
+const byte PIN_CATHODE_0_C_DPM_BIT = 1 << 4;        // pin 4: PORTD bit 4
+const byte PIN_CATHODE_0_D_DPM_BIT = 1 << 5;        // pin 5: PORTD bit 5
+const byte PIN_CATHODE_1_A_DPM_BIT = 1 << 6;        // pin 6: PORTD bit 6
+const byte PIN_CATHODE_1_B_DPM_BIT = 1 << 7;        // pin 7: PORTD bit 7
+const byte PIN_CATHODE_1_C_DPM_BIT = 1 << 0;        // pin 8: PORTB bit 0
+const byte PIN_CATHODE_1_D_DPM_BIT = 1 << 1;        // pin 9: PORTB bit 1
+const byte PIN_ANODE_1_DPM_BIT = 1 << 2;            // pin 10: PORTB bit 2
+const byte PIN_ANODE_2_DPM_BIT = 1 << 3;            // pin 11: PORTB bit 3
+const byte PIN_ANODE_3_DPM_BIT = 1 << 4;            // pin 12: PORTB bit 4
+const byte PIN_ANODE_4_DPM_BIT = 1 << 5;            // pin 13: PORTB bit 5
+const byte PIN_BUTTON_RIGHT_DPM_BIT = 1 << 0;       // pin A0 (14): PORTC bit 0
+const byte PIN_BUTTON_LEFT_DPM_BIT = 1 << 1;        // pin A1 (15): PORTC bit 1
+const byte PIN_BUTTON_RIGHT_LED_DPM_BIT = 1 << 2;   // pin A2 (16): PORTC bit 2
+const byte PIN_BUTTON_LEFT_LED_DPM_BIT = 1 << 3;    // pin A3 (17): PORTC bit 3
+const byte PIN_BUTTON_UTILITY_DPM_BIT = 1 << 4;     // pin A4 (18): PORTC bit 4
+const byte PIN_BUTTON_GROUND_DPM_BIT = 1 << 5;      // pin A5 (19): PORTC bit 5
 
 // The clock is designed to use 6 tubes, each one wired to a unique combination
 // of an anode pin (live power) and a cathode controller chip К155ИД1 (ground).

--- a/clock-hardware.h
+++ b/clock-hardware.h
@@ -64,7 +64,7 @@ const byte DIGITS_PER_TUBE = 10;
 const byte TUBE_ANODES[TUBE_COUNT] = {1, 1, 2, 2, 3, 3};
 const bool TUBE_CATHODE_CTRL_0[TUBE_COUNT] = {false, true, false, true, false, true};
 
-// controller values > 9 are unwired, and result in blank display
+// controller values > 9 result in blank display
 const byte BLANK = 15;
 
 // ИH-12A tubes

--- a/clock-hardware.h
+++ b/clock-hardware.h
@@ -25,6 +25,20 @@ const int PIN_ANODE_2 = 11;
 const int PIN_ANODE_3 = 12;
 const int PIN_ANODE_4 = 13;
 
+// Arduino Uno R1-R3 Direct Port Manipulation
+const byte PIN_CATHODE_0_A_DPM_BIT = 1 << 2;  // pin 2: PORTD bit 2
+const byte PIN_CATHODE_0_B_DPM_BIT = 1 << 3;  // pin 3: PORTD bit 3
+const byte PIN_CATHODE_0_C_DPM_BIT = 1 << 4;  // pin 4: PORTD bit 4
+const byte PIN_CATHODE_0_D_DPM_BIT = 1 << 5;  // pin 5: PORTD bit 5
+const byte PIN_CATHODE_1_A_DPM_BIT = 1 << 6;  // pin 6: PORTD bit 6
+const byte PIN_CATHODE_1_B_DPM_BIT = 1 << 7;  // pin 7: PORTD bit 7
+const byte PIN_CATHODE_1_C_DPM_BIT = 1 << 0;  // pin 8: PORTB bit 0
+const byte PIN_CATHODE_1_D_DPM_BIT = 1 << 1;  // pin 9: PORTB bit 1
+const byte PIN_ANODE_1_DPM_BIT = 1 << 2;  // pin 10: PORTB bit 2
+const byte PIN_ANODE_2_DPM_BIT = 1 << 3;  // pin 11: PORTB bit 3
+const byte PIN_ANODE_3_DPM_BIT = 1 << 4;  // pin 12: PORTB bit 4
+const byte PIN_ANODE_4_DPM_BIT = 1 << 5;  // pin 13: PORTB bit 5
+
 // button pins
 const int PIN_BUTTON_RIGHT = A0;
 const int PIN_BUTTON_LEFT = A1;


### PR DESCRIPTION
Convert Arduino control from using traditional (but slower) `digitalRead()` and `digitalWrite()` functions to instead using faster Direct Port Manipulation via bitwise operations on Arduino hardware registers. Update multiplex logic to include explicit dead/blank time between lit tubes.