### PR TITLE
WiFi Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
+ref/
 .*env
+clock-secrets.h

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 ref/
 .*env
 clock-secrets.h
+clock-secrets.dev.h

--- a/arduinix-chess-clock.ino
+++ b/arduinix-chess-clock.ino
@@ -8,7 +8,6 @@
  *  Behavior Constants
  * ===============================
  */
-const long SERIAL_SPEED_BAUD = 115200L;
 const int JACKPOT_STEP_DURATION_MS = 50;
 const int JACKPOT_FULL_ROUNDS = 5;
 const int JACKPOT_DURATION_MS = JACKPOT_STEP_DURATION_MS * DIGITS_PER_TUBE * JACKPOT_FULL_ROUNDS;
@@ -57,7 +56,7 @@ unsigned long lastDisplayRefreshTimestampUS = 0UL;
 bool multiplexIsLit = false;
 
 // chess clock state ♟⏲⏲♟
-ClockState currentClockState = IDLE;
+ClockState currentClockState = CLOCK_IDLE;
 unsigned long lastStatusUpdateTimestampMS = 0UL;
 unsigned long lastJackpotTimestampMS = 0UL;
 unsigned long lastEventStepTimestampMS = 0UL;
@@ -74,41 +73,8 @@ byte currentTurnTimerOption = 2;
  *  Initial Setup (Power On)
  * ===============================
  */
-void setup() 
-{
-  pinMode(PIN_ANODE_1, OUTPUT);
-  pinMode(PIN_ANODE_2, OUTPUT);
-  pinMode(PIN_ANODE_3, OUTPUT);
-  pinMode(PIN_ANODE_4, OUTPUT);
-  pinMode(PIN_CATHODE_0_A, OUTPUT);
-  pinMode(PIN_CATHODE_0_B, OUTPUT);
-  pinMode(PIN_CATHODE_0_C, OUTPUT);
-  pinMode(PIN_CATHODE_0_D, OUTPUT);
-  pinMode(PIN_CATHODE_1_A, OUTPUT);
-  pinMode(PIN_CATHODE_1_B, OUTPUT);
-  pinMode(PIN_CATHODE_1_C, OUTPUT);
-  pinMode(PIN_CATHODE_1_D, OUTPUT);
-  
-  blankTubes();
-
-  // use analog inputs as digital inputs for buttons
-  pinMode(PIN_BUTTON_RIGHT, INPUT_PULLUP);
-  pinMode(PIN_BUTTON_LEFT, INPUT_PULLUP);
-  pinMode(PIN_BUTTON_UTILITY, INPUT_PULLUP);
-
-  // use analog inputs as digital outputs for button LEDs
-  pinMode(PIN_BUTTON_RIGHT_LED, OUTPUT);
-  pinMode(PIN_BUTTON_LEFT_LED, OUTPUT);
-
-  // ground for button assembly
-  pinMode(PIN_BUTTON_GROUND, OUTPUT);
-  digitalWrite(PIN_BUTTON_GROUND, LOW);
-
-  setButtonLEDs(false, false);
-
-  Serial.begin(SERIAL_SPEED_BAUD);
-
-  printHardwareInfo();
+void setup() {
+  setupHardware();
 }
 
 /*
@@ -229,8 +195,9 @@ inline CountdownValues loopCountdown(unsigned long loopNow) {
     }
   } else if (elapsedMS >= timeoutLimit) {
     // countdown expired: change state
+    notifyTimeout(leftPlayersTurn);
     remainingMS = 0UL;
-    currentClockState = TIMEOUT;
+    currentClockState = CLOCK_TIMEOUT;
   } else {
     // countdown running: show remaining time
     setMultiplexClockTime(elapsedMS, remainingMS, loopNow, false);
@@ -301,49 +268,60 @@ inline void loopSendStatusUpdate(unsigned long loopNow, unsigned long elapsedMs,
 }
 
 inline void handleRightButtonPress(unsigned long loopNow) {
-  if (currentClockState == RUNNING && !leftPlayersTurn) {
+  if (currentClockState == CLOCK_RUNNING && !leftPlayersTurn) {
     leftPlayersTurn = !leftPlayersTurn;
+    notifyPlayerTurn(leftPlayersTurn);
     turnStartTimestampMS = loopNow;
-  } else if (currentClockState == MENU) {
+  } else if (currentClockState == CLOCK_MENU) {
+      // loop around if we're already on the largest option
     if (currentTurnTimerOption == TURN_TIMER_OPTIONS_COUNT - 1) {
       currentTurnTimerOption = 0;
     } else {
+      // cycle upward to larger timer level
       currentTurnTimerOption++;
     }
-  } else if (currentClockState == IDLE || currentClockState == DEMO) {
+  } else if (currentClockState == CLOCK_IDLE) {
+    notifyNewGame(false, TURN_TIMER_OPTIONS[currentTurnTimerOption].label);
     leftPlayersTurn = false;
     turnStartTimestampMS = loopNow;
-    currentClockState = RUNNING;
-  } else if (currentClockState == TIMEOUT) {
-    currentClockState = IDLE;
+    currentClockState = CLOCK_RUNNING;
+  } else if (currentClockState == CLOCK_TIMEOUT) {
+    currentClockState = CLOCK_IDLE;
   }
 }
 
 inline void handleLeftButtonPress(unsigned long loopNow) {
-  if (currentClockState == RUNNING && leftPlayersTurn) {
+  if (currentClockState == CLOCK_RUNNING && leftPlayersTurn) {
     leftPlayersTurn = !leftPlayersTurn;
+    notifyPlayerTurn(leftPlayersTurn);
     turnStartTimestampMS = loopNow;
-  } else if (currentClockState == MENU) {
+  } else if (currentClockState == CLOCK_MENU) {
     if (currentTurnTimerOption == 0) {
+      // loop around if we're already on the smallest option
       currentTurnTimerOption = TURN_TIMER_OPTIONS_COUNT - 1;
     } else {
+      // cycle downward to smaller timer level
       currentTurnTimerOption--;
     }
-  } else if (currentClockState == IDLE || currentClockState == DEMO) {
+  } else if (currentClockState == CLOCK_IDLE) {
+    notifyNewGame(true, TURN_TIMER_OPTIONS[currentTurnTimerOption].label);
     leftPlayersTurn = true;
     turnStartTimestampMS = loopNow;
-    currentClockState = RUNNING;
-  } else if (currentClockState == TIMEOUT) {
-    currentClockState = IDLE;
+    currentClockState = CLOCK_RUNNING;
+  } else if (currentClockState == CLOCK_TIMEOUT) {
+    currentClockState = CLOCK_IDLE;
   }
 }
 
 inline void handleUtilityButtonPress(unsigned long loopNow) {
-  if (currentClockState == IDLE) {
-    currentClockState = MENU;
-  } else if (currentClockState == DEMO || currentClockState == MENU || currentClockState == TIMEOUT || currentClockState == RUNNING) {
-    currentClockState = IDLE;
-    turnStartTimestampMS = 0;
+  if (currentClockState == CLOCK_IDLE) {
+    currentClockState = CLOCK_MENU;
+  } else if (
+    currentClockState == CLOCK_MENU
+    || currentClockState == CLOCK_TIMEOUT
+    || currentClockState == CLOCK_RUNNING
+  ) {
+    currentClockState = CLOCK_IDLE;
   }
 }
 
@@ -413,24 +391,23 @@ void loop() {
   
   CountdownValues cv = { 0UL, 0UL };
 
-  // update values to display in multiplexDisplayValues[] based on current clock state
-  if (currentClockState == RUNNING) {
+  // handle behavior based on current clock state. generally, update the
+  // tube display by making changes to multiplexDisplayValues[], and 
+  // occasionally change to other states (e.g. loopCountdown() will change
+  // `currentClockState` to CLOCK_TIMEOUT when appropriate)
+  if (currentClockState == CLOCK_RUNNING) {
     cv = loopCountdown(now);
-  } else if (currentClockState == TIMEOUT) {
+  } else if (currentClockState == CLOCK_TIMEOUT) {
     cv = { TURN_TIMER_OPTIONS[currentTurnTimerOption].turnLimitMS, 0UL };
     loopTimeout(now);
-  } else if (currentClockState == MENU) {
+  } else if (currentClockState == CLOCK_MENU) {
     loopMenu(now);
-  } else if (currentClockState == DEMO) {
-    // loopDemoCount(now);
-  } else if (currentClockState == IDLE) {
+  } else if (currentClockState == CLOCK_IDLE) {
     loopIdle();
   }
 
   // display current values in multiplexDisplayValues[]
   loopMultiplex();
 
-  #if defined(ARDUINO_AVR_UNO)
-    loopSendStatusUpdate(now, cv.elapsedMS, cv.remainingMS);
-  #endif
+  loopHardware(now);
 }

--- a/arduinix-chess-clock.ino
+++ b/arduinix-chess-clock.ino
@@ -195,9 +195,12 @@ inline CountdownValues loopCountdown(unsigned long loopNow) {
     }
   } else if (elapsedMS >= timeoutLimit) {
     // countdown expired: change state
-    notifyTimeout(leftPlayersTurn);
     remainingMS = 0UL;
     currentClockState = CLOCK_TIMEOUT;
+    
+    blankTubes();
+    setButtonLEDs(leftPlayersTurn, !leftPlayersTurn);
+    notifyTimeout(leftPlayersTurn);
   } else {
     // countdown running: show remaining time
     setMultiplexClockTime(elapsedMS, remainingMS, loopNow, false);
@@ -270,8 +273,11 @@ inline void loopSendStatusUpdate(unsigned long loopNow, unsigned long elapsedMs,
 inline void handleRightButtonPress(unsigned long loopNow) {
   if (currentClockState == CLOCK_RUNNING && !leftPlayersTurn) {
     leftPlayersTurn = !leftPlayersTurn;
-    notifyPlayerTurn(leftPlayersTurn);
     turnStartTimestampMS = loopNow;
+
+    blankTubes();
+    setButtonLEDs(leftPlayersTurn, !leftPlayersTurn);
+    notifyPlayerTurn(leftPlayersTurn);
   } else if (currentClockState == CLOCK_MENU) {
       // loop around if we're already on the largest option
     if (currentTurnTimerOption == TURN_TIMER_OPTIONS_COUNT - 1) {
@@ -281,10 +287,12 @@ inline void handleRightButtonPress(unsigned long loopNow) {
       currentTurnTimerOption++;
     }
   } else if (currentClockState == CLOCK_IDLE) {
-    notifyNewGame(false, TURN_TIMER_OPTIONS[currentTurnTimerOption].label);
     leftPlayersTurn = false;
     turnStartTimestampMS = loopNow;
     currentClockState = CLOCK_RUNNING;
+    
+    setButtonLEDs(leftPlayersTurn, !leftPlayersTurn);
+    notifyNewGame(false, TURN_TIMER_OPTIONS[currentTurnTimerOption].label);
   } else if (currentClockState == CLOCK_TIMEOUT) {
     currentClockState = CLOCK_IDLE;
   }
@@ -293,8 +301,11 @@ inline void handleRightButtonPress(unsigned long loopNow) {
 inline void handleLeftButtonPress(unsigned long loopNow) {
   if (currentClockState == CLOCK_RUNNING && leftPlayersTurn) {
     leftPlayersTurn = !leftPlayersTurn;
-    notifyPlayerTurn(leftPlayersTurn);
     turnStartTimestampMS = loopNow;
+    
+    blankTubes();
+    setButtonLEDs(leftPlayersTurn, !leftPlayersTurn);
+    notifyPlayerTurn(leftPlayersTurn);
   } else if (currentClockState == CLOCK_MENU) {
     if (currentTurnTimerOption == 0) {
       // loop around if we're already on the smallest option
@@ -304,10 +315,12 @@ inline void handleLeftButtonPress(unsigned long loopNow) {
       currentTurnTimerOption--;
     }
   } else if (currentClockState == CLOCK_IDLE) {
-    notifyNewGame(true, TURN_TIMER_OPTIONS[currentTurnTimerOption].label);
     leftPlayersTurn = true;
     turnStartTimestampMS = loopNow;
     currentClockState = CLOCK_RUNNING;
+
+    setButtonLEDs(leftPlayersTurn, !leftPlayersTurn);
+    notifyNewGame(true, TURN_TIMER_OPTIONS[currentTurnTimerOption].label);
   } else if (currentClockState == CLOCK_TIMEOUT) {
     currentClockState = CLOCK_IDLE;
   }

--- a/clock-data-types.h
+++ b/clock-data-types.h
@@ -9,7 +9,7 @@
 #ifndef _CLOCK_DATA_TYPES_H
 #define _CLOCK_DATA_TYPES_H
 
-enum ClockState { IDLE, RUNNING, TIMEOUT, MENU, DEMO };
+enum ClockState { CLOCK_IDLE, CLOCK_RUNNING, CLOCK_TIMEOUT, CLOCK_MENU };
 
 typedef struct {
   byte displayValues[TUBE_COUNT];

--- a/clock-hardware.h
+++ b/clock-hardware.h
@@ -472,18 +472,8 @@ inline void loopHardware(unsigned long loopNow) {
     // this may eventually be something like communication with an RTC chip
 
   #elif defined(ARDUINO_UNOWIFIR4)
-    // TODO: look into changing WiFi.status() to be async in the same way that
-    // Modem.write_nowait() works when called by WiFiClient.write().
-    // ALT: Do this during a blank period at the end of every jackpot. If going
-    // this way, also refactor jackpot decision to be in main loop()
-    // ALT2: maybe try multiplexing a row at once, and sneak this in after a
-    // dead period at the end (it'll probably still blink tho, and a con could
-    // this makes buttons less unresponsive.
-    //
-    // For now, leave this disabled, because it causes a long enough delay to 
-    // trip up multiplexing and to cause pulses and flashes.
-    // 
-    // loopCheckWifiConnection();
+    // wifi reconnecting is handled automatically by the ESP32-C3
+
   #endif
 }
 

--- a/clock-strings.h
+++ b/clock-strings.h
@@ -1,0 +1,10 @@
+#ifndef _CLOCK_STRINGS_H
+#define _CLOCK_STRINGS_H
+
+#define playerString(leftPlayersTurn) (leftPlayersTurn ? "Left" : "Right")
+
+const char* NEW_GAME_MSG = "New Game Started! Turn Limit: %s | Starting Player: %s";
+const char* TURN_CHANGE_MSG = "Your Move!";
+const char* TIMEOUT_MSG = "Game Over! %s Player Timed Out";
+
+#endif _CLOCK_STRINGS_H

--- a/clock-wifi.h
+++ b/clock-wifi.h
@@ -1,0 +1,199 @@
+#ifndef _CLOCK_WIFI_H
+#define _CLOCK_WIFI_H
+
+#include <WiFiS3.h>
+
+#include "clock-strings.h"
+#include "clock-secrets.h"
+
+const char* SSID = SECRET_SSID;
+const char* PASS = SECRET_PASS;
+
+const char* TOPIC_LEFT = SECRET_TOPIC_LEFT;
+const char* TOPIC_RIGHT = SECRET_TOPIC_RIGHT;
+const char* NTFY_SERVER = "ntfy.sh";
+
+const char* CONN_KEEP_ALIVE = "keep-alive";
+const char* CONN_CLOSE = "close";
+const char* NTFY_REQUEST = "POST /%s HTTP/1.1\nHost: ntfy.sh\nContent-Type: text/plain\nContent-Length: %d\nConnection: %s\n\n%s\n";
+
+int wifiConnectionStatus = WL_IDLE_STATUS;
+WiFiClient client;
+
+inline void printMacAddress(byte mac[]) {
+  for (int i = 0; i < 6; i++) {
+    if (i > 0) {
+      Serial.print(":");
+    }
+    if (mac[i] < 16) {
+      Serial.print("0");
+    }
+    Serial.print(mac[i], HEX);
+  }
+  Serial.println();
+}
+
+inline void printNetworkInfo() {
+  Serial.print("IP Address: ");
+  IPAddress ip = WiFi.localIP();
+  Serial.println(ip);
+
+  Serial.print("MAC Address: ");
+  byte mac[6];
+  WiFi.macAddress(mac);
+  printMacAddress(mac);
+}
+
+inline void printWifiInfo() {
+  Serial.print("SSID: ");
+  Serial.println(WiFi.SSID());
+
+  // AP/Router MAC
+  byte bssid[6];
+  Serial.print("BSSID: ");
+  WiFi.BSSID(bssid);
+  printMacAddress(bssid);
+
+  Serial.print("Signal Strength (RSSI): ");
+  long rssi = WiFi.RSSI();
+  Serial.println(rssi);
+}
+
+inline const char* statusCodeString(int status) {
+  switch(status) {
+    case WL_IDLE_STATUS: return "WL_IDLE_STATUS";
+    case WL_NO_SSID_AVAIL: return "WL_NO_SSID_AVAIL";
+    case WL_SCAN_COMPLETED: return "WL_SCAN_COMPLETED";
+    case WL_CONNECTED: return "WL_CONNECTED";
+    case WL_CONNECT_FAILED: return "WL_CONNECT_FAILED";
+    case WL_CONNECTION_LOST: return "WL_CONNECTION_LOST";
+    case WL_DISCONNECTED: return "WL_DISCONNECTED";
+    case WL_AP_LISTENING: return "WL_AP_LISTENING";
+    case WL_AP_CONNECTED: return "WL_AP_CONNECTED";
+    case WL_AP_FAILED: return "WL_AP_FAILED";
+    case WL_NO_SHIELD: return "WL_NO_SHIELD/WL_NO_SHIELD";
+    default: return "Unknown";
+  }
+}
+
+inline bool setupWifi() {
+  wifiConnectionStatus = WiFi.status();
+
+  if (wifiConnectionStatus == WL_NO_MODULE) {
+    Serial.println("Communication with WiFi module failed!");
+    return false;
+  } else {
+    Serial.print("WiFi module status: ");
+    Serial.println(statusCodeString(wifiConnectionStatus));
+  }
+
+  String fv = WiFi.firmwareVersion();
+  if (fv < WIFI_FIRMWARE_LATEST_VERSION) {
+    Serial.println("Please upgrade the WiFi module firmware.");
+    Serial.print("Current: ");
+    Serial.println(fv);
+    Serial.print("Latest: ");
+    Serial.println(WIFI_FIRMWARE_LATEST_VERSION);
+  } else {
+    Serial.print("WiFi module firmware is up-to-date: ");
+    Serial.println(fv);
+  }
+
+  Serial.print("Attempting to connect to SSID: ");
+  Serial.println(SSID);
+  wifiConnectionStatus = WiFi.begin(SSID, PASS);
+
+  if (wifiConnectionStatus == WL_CONNECTED) {
+    Serial.println("WiFi Connected!");
+    printWifiInfo();
+    printNetworkInfo();
+  } else {
+    Serial.print("Error connecting to WiFi network! Status: ");
+    Serial.println(statusCodeString(wifiConnectionStatus));
+  }
+
+  return wifiConnectionStatus == WL_CONNECTED;
+}
+
+inline bool loopCheckWifiConnection(unsigned long loopNow) {
+  // if (loopNow - lastWifiCheckReconnectTime >= WIFI_CHECK_AND_RECONNECT_FREQUENCY_MS) {
+    Serial.println("Checking WiFi Status...");
+
+    unsigned long before = micros();
+    int currentStatus = WiFi.status();
+    unsigned long diff = micros() - before;
+
+    // lastWifiCheckReconnectTime = loopNow;
+
+    // take action only if status has changed
+    if (wifiConnectionStatus != currentStatus) {
+      if (currentStatus == WL_CONNECTED) {
+        Serial.println("WiFi Connected!");
+        printWifiInfo();
+        printNetworkInfo();
+      } else {
+        Serial.print("WiFi Connection Lost - Current Status: ");
+        Serial.println(statusCodeString(currentStatus));
+
+        Serial.print("Attempting to reconnect to SSID: ");
+        Serial.println(SSID);
+
+        WiFi.begin(SSID, PASS);
+      }
+
+      wifiConnectionStatus = currentStatus;
+    }
+    else {
+      Serial.print("No WiFi status change. Time to check (us): ");
+      Serial.println(diff);
+    }
+
+    return wifiConnectionStatus == WL_CONNECTED;
+  // }
+}
+
+#define playerTopic(leftPlayersTurn) (leftPlayersTurn ? TOPIC_LEFT : TOPIC_RIGHT)
+
+inline void notifyNewGame(bool leftPlayersTurn, const char* label) {
+  char messageBuffer[100] = "";
+  char reqBuffer1[200] = "";
+  char reqBuffer2[200] = "";
+
+  snprintf(messageBuffer, 100, NEW_GAME_MSG, label, playerString(leftPlayersTurn));
+  snprintf(reqBuffer1, 200, NTFY_REQUEST, TOPIC_LEFT, strlen(messageBuffer), CONN_KEEP_ALIVE, messageBuffer);
+  snprintf(reqBuffer2, 200, NTFY_REQUEST, TOPIC_RIGHT, strlen(messageBuffer), CONN_CLOSE, messageBuffer);
+
+  if (client.connect(NTFY_SERVER, 80)) {
+    client.println(reqBuffer1);
+    client.println(reqBuffer2);
+    client.stop();
+  }
+}
+
+inline void notifyPlayerTurn(bool leftPlayersTurn) {
+  char reqBuffer[150] = "";
+  snprintf(reqBuffer, 150, NTFY_REQUEST, playerTopic(leftPlayersTurn), strlen(TURN_CHANGE_MSG), CONN_CLOSE, TURN_CHANGE_MSG);
+
+  if (client.connect(NTFY_SERVER, 80)) {
+    client.println(reqBuffer);
+    client.stop();
+  }
+}
+
+inline void notifyTimeout(bool leftPlayersTurn) {
+  char messageBuffer[100] = "";
+  char reqBuffer1[200] = "";
+  char reqBuffer2[200] = "";
+
+  snprintf(messageBuffer, 100, TIMEOUT_MSG, playerString(leftPlayersTurn));
+  snprintf(reqBuffer1, 200, NTFY_REQUEST, TOPIC_LEFT, strlen(messageBuffer), CONN_KEEP_ALIVE, messageBuffer);
+  snprintf(reqBuffer2, 200, NTFY_REQUEST, TOPIC_RIGHT, strlen(messageBuffer), CONN_CLOSE, messageBuffer);
+
+  if (client.connect(NTFY_SERVER, 80)) {
+    client.println(reqBuffer1);
+    client.println(reqBuffer2);
+    client.stop();
+  }
+}
+
+#endif _CLOCK_WIFI_H


### PR DESCRIPTION
Add WiFi support when Arduino Uno R4 WiFi hardware is used, and send ntfy.sh notifications directly from the clock in this case.

Also for AVR-based Unos, change from using continuous state synchronization updates over serial to instead only sending serial updates for notification events.